### PR TITLE
fix(license): Licensing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 ["package"]
 name = "amble"
 description = "First class, scalable rust project generator with batteries included."
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 license = "MIT"
 authors = ["refcell"]
@@ -36,6 +36,7 @@ gitignores = "2.3"
 prettytable = "0.10"
 image = "0.24"
 lice = "0.1"
+aho-corasick = "1.1.2"
 
 [dev-dependencies]
 tempfile = "3.8"


### PR DESCRIPTION
**Description**

Optimizes license pattern replacement using [`aho-corasick`](https://github.com/BurntSushi/aho-corasick).
The `aho_corasick` crate implements the linear-in-string-length Aho Corasick algorithm for string searching using SIMD when available.
Under the hood, `aho_corasick` builds a finite state machine for executing string searches.

Using Aho Corasick in place of chained, native rust `String` replace method calls optimizes away multiple string reconstructions.

This PR also extends license construction with additional template patterns to match dynamic year and copyright owner values against.

Fixes #25
