### PR TITLE
feat(git): `--git` flag to allow create git repository 

### DIFF
--- a/bin/amble/src/cli.rs
+++ b/bin/amble/src/cli.rs
@@ -3,7 +3,7 @@ use clap::{ArgAction, Parser};
 use inquire::Confirm;
 use ptree::TreeBuilder;
 
-use preamble::{bins, cargo, ci, etc, gitignore, libs, license, root, telemetry, utils};
+use preamble::{bins, cargo, ci, etc, git, gitignore, libs, license, root, telemetry, utils};
 
 /// Command line arguments.
 #[derive(Parser, Debug)]
@@ -106,6 +106,10 @@ pub struct Args {
     /// or unspecified directory, an error will be thrown.
     #[arg(default_value = ".")]
     project_dir: String,
+
+    /// Create git repository with user's github username
+    #[arg(long)]
+    git: Option<Option<String>>,
 }
 
 /// CLI Entrypoint.
@@ -132,6 +136,7 @@ pub fn run() -> Result<()> {
         list,
         dependencies,
         mut etc,
+        git,
     } = Args::parse();
     let project_dir_path = std::path::Path::new(&project_dir);
 
@@ -188,6 +193,12 @@ pub fn run() -> Result<()> {
 
     if gitignore {
         gitignore::create(project_dir_path, dry_run, Some(&mut builder))?;
+    }
+
+    if let Some(git) = git {
+        git::create(project_dir_path, dry_run, git)?;
+    } else if !bin && !lib {
+        git::create(project_dir_path, dry_run, None)?;
     }
 
     if etc {

--- a/crates/preamble/src/git.rs
+++ b/crates/preamble/src/git.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use std::path::Path;
+use tracing::instrument;
+
+/// Create git repository with given github username. If github username is not specified, try to grab one
+#[instrument(name = "git", skip(dir, dry))]
+pub fn create(dir: &Path, dry: bool, github_username: Option<String>) -> Result<()> {
+    crate::utils::create_dir_gracefully!(dir, dry);
+
+    if !dry {
+        // Execute the `cargo init --bin` command in the given directory.
+        tracing::debug!("Executing `git init -b main` in {:?}", dir);
+        let output = std::process::Command::new("git")
+            .arg("init")
+            .arg("-b")
+            .arg("main")
+            .current_dir(dir)
+            .output()?;
+        tracing::debug!("`git init -b main` output: {:?}", output);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn test_create() {
+        let dir = tempdir().unwrap();
+        let dir_path_buf = dir.path().to_path_buf();
+        let package_dir = dir_path_buf.join("example");
+        create(&package_dir, false, None).unwrap();
+
+        assert!(package_dir.exists());
+        assert!(package_dir.join(".git").exists());
+    }
+}

--- a/crates/preamble/src/lib.rs
+++ b/crates/preamble/src/lib.rs
@@ -43,6 +43,9 @@ pub mod etc;
 /// Gitignore File Handler
 pub mod gitignore;
 
+/// Git repository handler
+pub mod git;
+
 /// Workspace Library Crate Builders
 pub mod libs;
 


### PR DESCRIPTION
From issue #55 
Tasks:
- [x] Create git repository on `--git` flag set or `--full` flag is used.
- [ ] Parse github username from user input.